### PR TITLE
Adjustment to hostname listing

### DIFF
--- a/Mnemosyne Of Mine/Program.cs
+++ b/Mnemosyne Of Mine/Program.cs
@@ -135,8 +135,8 @@ namespace Mnemosyne_Of_Mine
                                 archiveURL = Archiving.Archive(@"archive.is", link);
                                 if (Archiving.VerifyArchiveResult(link, archiveURL))
                                 {
-                                    string hostname = new Uri(link).Host;
-                                    ArchiveLinks.Add($"* **Link: {counter.ToString()}** ({hostname}): {archiveURL}\n");
+                                    string hostname = new Uri(link).Host.Replace("www.", ""); 
+                                    ArchiveLinks.Add($"* **Link: {counter.ToString()}** [{hostname}]({link}): {archiveURL}\n");
                                     ++counter;
                                 }
                             }


### PR DESCRIPTION
Spotted here: https://www.reddit.com/r/KotakuInAction/comments/4nofra/showerthought_progressives_never_seem_to_realize/d45ki03

This _should_ make the hostname a markdown'd link to original URL and strip the "www." if present, so it doesn't auto-link in that broken way it did.
